### PR TITLE
New CI

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,37 @@
+---
+name: Merges
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"
+    steps:
+      - name: Set Maven Options
+        run:
+          echo "::set-env name=MAVEN_OPTS::-Dmaven.repo.local=$HOME/.m2/repository"
+      - uses: actions/checkout@v2
+      - name: Set up Java 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache Packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build and Run Tests
+        run: mvn $MAVEN_CLI_OPTS install
+      - name: Archive SNAPSHOTs
+        uses: actions/upload-artifact@v1
+        with:
+          name: snapshot
+          path: target

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,32 @@
+---
+name: Pull Requests
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"
+    steps:
+      - name: Set Maven Options
+        run:
+          echo "::set-env name=MAVEN_OPTS::-Dmaven.repo.local=$HOME/.m2/repository"
+      - uses: actions/checkout@v2
+      - name: Set up Java 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache Packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build and Run Tests
+        run: mvn $MAVEN_CLI_OPTS install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+---
+name: Releases
+
+# yamllint disable-line rule:truthy
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Java 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Strip SNAPSHOT Version
+        run: |
+          mvn $MAVEN_CLI_OPTS \
+            versions:set versions:update-child-modules versions:commit \
+            -DnewVersion=${VERSION/refs\/tags\/} \
+            -DgenerateBackupPoms=false
+        env:
+          VERSION: ${{ github.ref }}
+      - name: Publish GitHub Packages
+        run: |
+          mvn $MAVEN_CLI_OPTS \
+            deploy \
+            -D altDeploymentRepository=release::default::${MAVEN_RELEASE_REPO_URL}
+        env:
+          MAVEN_RELEASE_REPO_USER: ${{ github.actor }}
+          MAVEN_RELEASE_REPO_PASS: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_RELEASE_REPO_URL: https://maven.pkg.github.com/${{ github.repository }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.tox/
+*.retry
+*.swp

--- a/.m2/settings.xml
+++ b/.m2/settings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <servers>
+    <server>
+      <id>release</id>
+      <username>${env.MAVEN_RELEASE_REPO_USER}</username>
+      <password>${env.MAVEN_RELEASE_REPO_PASS}</password>
+    </server>
+  </servers>
+</settings>


### PR DESCRIPTION
Add new CI please!
# My CI/CD Ready Repo

## Roles can be installed with:

  # Future this will be `install linuxfoundation.ci`
  #  which will contain all the other roles as dependencies
  #  and may be done as a post-run script for cookiecutter
  ansible-galaxy install -r requirements.yml --roles-path roles

## Individual roles can be tested with the following command:

  # In the future this will be molecule, or an ansible specific runner
  docker run --rm -it \
  -v $PWD:/app \
  -w /app \
  -e ANSIBLE_STDOUT_CALLBACK=unixy \
  -e WORKSPACE=/app \
  williamyeh/ansible:alpine3 \
  ansible-playbook -c local .playbooks/verify.yml





# Java Toolchain

## Environment

- MAVEN_RELEASE_REPO_URL
  URL of the release repository

- MAVEN_RELEASE_REPO_USER
  Username for the release repository

- MAVEN_RELEASE_REPO_PASS
  Password for the release repository

- MAVEN_RELEASE_REPO
  Nmae of the release repository

- MAVEN_SNAPSHOT_REPO_URL
  URL of the snapshot repository

- MAVEN_SNAPSHOT_REPO_USER
  Username for the snapshot repository

- MAVEN_SNAPSHOT_REPO_PASS
  Password for the snapshot repository

- MAVEN_SNAPSHOT_REPO
  Nmae of the snapshot repository






Signed-off-by: ITX CI \<itx@linuxfoundation.org\>
on-behalf-of: @linuxfoundation-it \<itx@linuxfoundation.org\>